### PR TITLE
Add support for fading between colorspaces other than RGBA

### DIFF
--- a/UIColor+CrossFade.h
+++ b/UIColor+CrossFade.h
@@ -51,4 +51,9 @@
                                 lastColor:(UIColor *)lastColor
                                     inSteps:(NSUInteger)steps;
 
+/**
+ * Convert UIColor to RGBA colorspace. Used for cross-colorspace interpolation.
+ */
++ (UIColor *)colorConvertedToRGBA:(UIColor *)colorToConvert;
+
 @end

--- a/UIColor+CrossFade.m
+++ b/UIColor+CrossFade.m
@@ -35,12 +35,11 @@
                                secondColor:(UIColor *)secondColor 
                                    atRatio:(CGFloat)ratio {
     
-    // If the UIColor arguments lie in different color spaces, return nil
-    // todo: convert between color spaces (http://arstechnica.com/apple/guides/2009/02/iphone-development-accessing-uicolor-components.ars)
+    // Convert to common RGBA colorspace if needed
     if (CGColorGetColorSpace(firstColor.CGColor) != CGColorGetColorSpace(secondColor.CGColor))
     {
-        NSLog(@"Attempted to interpolate between colors with different colorspaces: %@ and %@", firstColor, secondColor);
-        return nil;
+        firstColor = [UIColor colorConvertedToRGBA:firstColor];
+        secondColor = [UIColor colorConvertedToRGBA:secondColor];
     }
     
     // Grab color components
@@ -91,6 +90,34 @@
     
     [colors addObject:lastColor];
     return colors;
+}
+                          
++ (UIColor *)colorConvertedToRGBA:(UIColor *)colorToConvert;
+{
+    CGFloat red;
+    CGFloat green;
+    CGFloat blue;
+    CGFloat alpha;
+    
+    // Convert color to RGBA with a CGContext. UIColor's getRed:green:blue:alpha: doesn't work across color spaces. Adapted from http://stackoverflow.com/a/4700259
+
+    alpha = CGColorGetAlpha(colorToConvert.CGColor);
+    
+    CGColorRef opaqueColor = CGColorCreateCopyWithAlpha(colorToConvert.CGColor, 1.0f);
+    CGColorSpaceRef rgbColorSpace = CGColorSpaceCreateDeviceRGB();
+    unsigned char resultingPixel[CGColorSpaceGetNumberOfComponents(rgbColorSpace)];
+    CGContextRef context = CGBitmapContextCreate(&resultingPixel, 1, 1, 8, 4, rgbColorSpace, kCGImageAlphaNoneSkipLast);
+    CGContextSetFillColorWithColor(context, opaqueColor);
+    CGColorRelease(opaqueColor);
+    CGContextFillRect(context, CGRectMake(0.f, 0.f, 1.f, 1.f));
+    CGContextRelease(context);
+    CGColorSpaceRelease(rgbColorSpace);
+    
+    red = resultingPixel[0] / 255.0f;
+    green = resultingPixel[1] / 255.0f;
+    blue = resultingPixel[2] / 255.0f;
+
+    return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
 }
 
 @end


### PR DESCRIPTION
_One last thing._

Cross fading between colors of a colorspace other than RGBA, e.g. [UIColor colorWithWhite:0.5f alpha:1.0f], bombs. Here's a fix that keeps things running smoothly.
