### PR TITLE
Removed warning of different enumerations implicit conversion

### DIFF
--- a/UIColor+CrossFade.m
+++ b/UIColor+CrossFade.m
@@ -159,7 +159,7 @@
     CGColorRef opaqueColor = CGColorCreateCopyWithAlpha(colorToConvert.CGColor, 1.0f);
     CGColorSpaceRef rgbColorSpace = CGColorSpaceCreateDeviceRGB();
     unsigned char resultingPixel[CGColorSpaceGetNumberOfComponents(rgbColorSpace)];
-    CGContextRef context = CGBitmapContextCreate(&resultingPixel, 1, 1, 8, 4, rgbColorSpace, kCGImageAlphaNoneSkipLast);
+    CGContextRef context = CGBitmapContextCreate(&resultingPixel, 1, 1, 8, 4, rgbColorSpace, (CGBitmapInfo)kCGImageAlphaNoneSkipLast);
     CGContextSetFillColorWithColor(context, opaqueColor);
     CGColorRelease(opaqueColor);
     CGContextFillRect(context, CGRectMake(0.f, 0.f, 1.f, 1.f));


### PR DESCRIPTION
I have added a explicit casting to avoid a warning that can appear depending on the Xcode build settings
